### PR TITLE
feat: prerelease & metadata

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,6 +15,8 @@ const (
 	flagRevision  = "revision"
 	flagDir       = "dir"
 	flagFile      = "file"
+	flagPrerelease = "prerelease"
+	flagMetadata = "metadata"
 	flagChangelog = "changelog"
 	flagLatest    = "latest"
 	flagVersion   = "version"

--- a/next.go
+++ b/next.go
@@ -43,6 +43,20 @@ func nextCommand(c *cli.Context) error {
 
 	log.Infof("found max change: %s", commits.MaxChange())
 	nextVersion := nextReleaseByChange(latest, commits.MaxChange())
+	pre := c.String(flagPrerelease)
+	if pre != "" {
+		nextVersion, err = nextVersion.SetPrerelease(pre)
+		if err != nil {
+			return cli.NewExitError(err, 7)
+		}
+	}
+	meta := c.String(flagMetadata)
+	if meta != "" {
+		nextVersion, err = nextVersion.SetMetadata(meta)
+		if err != nil {
+			return cli.NewExitError(err, 8)
+		}
+	}
 	os.Stdout.WriteString(nextVersion.String())
 	return nil
 }
@@ -53,6 +67,18 @@ func nextFlags() []cli.Flag {
 			Name:  flagFile,
 			Value: "VERSION",
 			Usage: "file to use to get the commit of last modification. That file must include the latest version",
+		},
+		cli.StringFlag{
+			Name:  flagPrerelease,
+			Value: "",
+			EnvVar: "RELEASE_PRERELEASE",
+			Usage: "add prerelease tag",
+		},
+		cli.StringFlag{
+			Name:  flagMetadata,
+			Value: "",
+			EnvVar: "RELEASE_METADATA",
+			Usage: "add metadata tag",
 		},
 	}
 }


### PR DESCRIPTION
implementing flags for next-version command:
- prerelase adds a prerelease. e.g.: 1.0.12-rc1
- metadata adds metadata to a version. e.g.: 1.0.12+0fca312
both flags can be used and may be set up with environment variables:

RELEASE_PRERELEASE
RELEASE_METADATA